### PR TITLE
Add GitHub action to check theme build commands

### DIFF
--- a/.github/workflows/magento-theme-build.yml
+++ b/.github/workflows/magento-theme-build.yml
@@ -1,0 +1,45 @@
+name: Magento Theme Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Environment setup
+        run: |
+          brew install bats-core mkcert
+          mkcert -install
+
+      - name: Install ddev
+        run: brew install ddev/ddev/ddev
+
+      - name: Set up ddev
+        run: |
+          ddev config --project-type=magento2 --docroot=pub --create-docroot
+          ddev start
+
+      - name: Install Magento
+        run: |
+          ddev exec composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition:2.4.3-p1 .
+          ddev exec bin/magento setup:install --base-url=http://magento2.ddev.site --db-host=db --db-name=db --db-user=db --db-password=db --admin-firstname=admin --admin-lastname=admin --admin-email=admin@example.com --admin-user=admin --admin-password=admin123 --language=en_US --currency=USD --timezone=America/Chicago --use-rewrites=1
+
+      - name: Run theme build commands
+        run: |
+          ddev exec bin/magento setup:upgrade
+          ddev exec bin/magento setup:di:compile
+          ddev exec bin/magento setup:static-content:deploy -f

--- a/README.md
+++ b/README.md
@@ -178,3 +178,18 @@ Feel free to send your improvements as [Pull request](https://github.com/OpenFor
 ## License
 
 [License](./LICENSE) | by [Mathias Elle](https://www.linkedin.com/in/mathias-elle-842783102/)
+
+## GitHub Action for Checking Theme Build Commands
+
+We have added a new GitHub action to set up a Magento demo store and check theme build commands. This action runs on `push` and `pull_request` events.
+
+### Usage
+
+To use the new GitHub action, follow these steps:
+
+1. Ensure that the `.github/workflows/magento-theme-build.yml` file is present in your repository.
+2. The action will automatically run on `push` and `pull_request` events.
+
+The action includes steps to set up ddev, install Magento, and run theme build commands.
+
+For more details, refer to the `.github/workflows/magento-theme-build.yml` file in your repository.


### PR DESCRIPTION
Fixes #55

Add a new GitHub action to set up a Magento demo store and check theme build commands.

* **New GitHub Action**: Add `.github/workflows/magento-theme-build.yml` to set up a Magento demo store and check theme build commands.
  - Runs on `push` and `pull_request` events.
  - Includes steps to set up Homebrew, install ddev, set up ddev, install Magento, and run theme build commands.

* **README Update**: Update `README.md` to include instructions on how to use the new GitHub action for checking theme build commands.
  - Add a new section "GitHub Action for Checking Theme Build Commands" with usage instructions.

